### PR TITLE
Fix calculator image size when build

### DIFF
--- a/images/images.go
+++ b/images/images.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/mgutz/ansi"
@@ -122,6 +123,11 @@ func Insert(name, baseImage string) error {
 	if baseImg == nil {
 		return errors.New("ERROR: NIL Image ... ")
 	}
+	size, err := io.FileSize(baseImage)
+	if err != nil {
+		return err
+	}
+	baseImg.Size = strconv.FormatInt(size, 10)
 	newImg := NewImage(name, baseImage, baseImg.Version, baseImg.Size, baseImg.URL)
 	images[name] = newImg
 	return insertImageDB(newImg)

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -13,6 +13,15 @@ func FileExists(fileName string) bool {
 	return true
 }
 
+// FileSize get file size if a directory or a file exists
+func FileSize(fileName string) (int64, error) {
+	f, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		return 0, err
+	}
+	return f.Size(), nil
+}
+
 // Copy Copy a directory or a file from origen to a specific destiny
 // (for ex: insidy the rootFS of a container)
 func Copy(source, destination string, done chan bool) error {


### PR DESCRIPTION
**What type of PR is this?**
bugfix

**What this PR does / why we need it**:

When a user uses build command to build new images, it cannot be calculated that size. So that I fixed to update new image size with `os.Stat`

**Which issue(s) this PR fixes**:

Fixes # 128
